### PR TITLE
Upgraded eiffel-remrem-parent version from 0.0.8 to 1.0.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.0
+- Upgraded eiffel-remrem-parent version from 0.0.8 to 1.0.0.
+- Upgraded eiffel-remrem-shared version from 0.4.2 to 1.0.0.
+- Upgraded eiffel-remrem-semantics version from 0.5.3 to 1.0.0.
+
 ## 0.6.10
 - Fixed the publish-Cli logger and lang3 jar issues and property loading errors.  
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,12 +6,12 @@
     <parent>
         <groupId>com.github.Ericsson</groupId>
         <artifactId>eiffel-remrem-parent</artifactId>
-        <version>0.0.8</version>
+        <version>1.0.0</version>
     </parent>
     <properties>
-        <eiffel-remrem-publish.version>0.6.10</eiffel-remrem-publish.version>
-        <eiffel-remrem-shared.version>0.4.2</eiffel-remrem-shared.version>
-        <eiffel-remrem-semantics.version>0.5.3</eiffel-remrem-semantics.version>
+        <eiffel-remrem-publish.version>1.0.0</eiffel-remrem-publish.version>
+        <eiffel-remrem-shared.version>1.0.0</eiffel-remrem-shared.version>
+        <eiffel-remrem-semantics.version>1.0.0</eiffel-remrem-semantics.version>
     </properties>
     <artifactId>eiffel-remrem-publish</artifactId>
     <version>${eiffel-remrem-publish.version}</version>


### PR DESCRIPTION
### Upgraded the remrem components to 1.0.0
Upgraded eiffel-remrem-shared version from 0.4.2 to 1.0.0.
Upgraded eiffel-remrem-semantics version from 0.5.3 to 1.0.0.
Upgraded eiffel-remrem-parent version from 0.0.8 to 1.0.0.

### Sign-off
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

