### PR TITLE
Upgraded eiffel-remrem-semantics version from 2.0.3 to 2.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.0.1
+- Upgraded eiffel-remrem-semantics version from 2.0.3 to 2.0.4
+
 ## 2.0.0
 - Upgraded eiffel-remrem-semantics version from 1.0.1 to 2.0.3
 - Modified test cases as per agen version and tested with proper data

--- a/pom.xml
+++ b/pom.xml
@@ -9,9 +9,9 @@
         <version>2.0.0</version>
     </parent>
     <properties>
-        <eiffel-remrem-publish.version>2.0.0</eiffel-remrem-publish.version>
+        <eiffel-remrem-publish.version>2.0.1</eiffel-remrem-publish.version>
         <eiffel-remrem-shared.version>2.0.0</eiffel-remrem-shared.version>
-        <eiffel-remrem-semantics.version>2.0.3</eiffel-remrem-semantics.version>
+        <eiffel-remrem-semantics.version>2.0.4</eiffel-remrem-semantics.version>
     </properties>
     <artifactId>eiffel-remrem-publish</artifactId>
     <version>${eiffel-remrem-publish.version}</version>

--- a/publish-service/src/test/resources/expectedParsedEvents/expected_parsed_EiffelActivityStartedEvent.json
+++ b/publish-service/src/test/resources/expectedParsedEvents/expected_parsed_EiffelActivityStartedEvent.json
@@ -2,7 +2,7 @@
   "msgParams": {
     "meta": {
       "type": "EiffelActivityStartedEvent",
-      "version": "3.0.0",
+      "version": "4.0.0",
       "tags": [
         "product_development",
         "product_feature1"

--- a/publish-service/src/test/resources/expectedParsedEvents/expected_parsed_EiffelActivityTriggeredEvent.json
+++ b/publish-service/src/test/resources/expectedParsedEvents/expected_parsed_EiffelActivityTriggeredEvent.json
@@ -2,7 +2,7 @@
   "msgParams": {
     "meta": {
       "type": "EiffelActivityTriggeredEvent",
-      "version": "3.0.0",
+      "version": "4.0.0",
       "tags": [
         "product_master",
         "product_feature1"


### PR DESCRIPTION
### Description of the Change
Upgraded eiffel-remrem-semantics version from 2.0.3 to 2.0.4