### PR TITLE
REMReM lookups controlled per lookup link instead of globally per call.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## 2.0.17
+- REMReM lookups controlled 'failIfNoneFound' and 'failIfMultipleFound' lookups per lookup
+  object within an event instead of globally per call.
 - Removed Ericsson specific configuration from github.
 
 ## 2.0.16

--- a/publish-service/src/main/java/com/ericsson/eiffel/remrem/publish/controller/ProducerController.java
+++ b/publish-service/src/main/java/com/ericsson/eiffel/remrem/publish/controller/ProducerController.java
@@ -178,11 +178,13 @@ public class ProducerController {
         EnumSet<HttpStatus> getStatus = EnumSet.of(HttpStatus.SERVICE_UNAVAILABLE, HttpStatus.UNAUTHORIZED, HttpStatus.NOT_ACCEPTABLE, HttpStatus.EXPECTATION_FAILED, HttpStatus.INTERNAL_SERVER_ERROR, HttpStatus.UNPROCESSABLE_ENTITY);
 
         try {
-            String generateUrl=generateURLTemplate.getUrl()+"&failIfMultipleFound="+failIfMultipleFound+"&failIfNoneFound="+failIfNoneFound+"&lookupInExternalERs="+lookupInExternalERs+"&lookupLimit="+lookupLimit;
+            String generateUrl = generateURLTemplate.getUrl() + "&failIfMultipleFound=" + failIfMultipleFound
+                    + "&failIfNoneFound=" + failIfNoneFound + "&lookupInExternalERs=" + lookupInExternalERs
+                    + "&lookupLimit=" + lookupLimit;
             ResponseEntity<String> response = restTemplate.postForEntity(generateUrl,
                     entity, String.class, generateURLTemplate.getMap(msgProtocol, msgType));
 
-            if(response.getStatusCode() == HttpStatus.OK) {
+            if (response.getStatusCode() == HttpStatus.OK) {
                 log.info("The result from REMReM Generate is: " + response.getStatusCodeValue());
 
                 // publishing requires an array if you want status code

--- a/publish-service/src/main/java/com/ericsson/eiffel/remrem/publish/controller/ProducerController.java
+++ b/publish-service/src/main/java/com/ericsson/eiffel/remrem/publish/controller/ProducerController.java
@@ -175,10 +175,10 @@ public class ProducerController {
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
         HttpEntity<String> entity = new HttpEntity<>(bodyJsonOut, headers);
-        EnumSet<HttpStatus> getStatus = EnumSet.of(HttpStatus.SERVICE_UNAVAILABLE, HttpStatus.UNAUTHORIZED, HttpStatus.NOT_ACCEPTABLE, HttpStatus.EXPECTATION_FAILED, HttpStatus.INTERNAL_SERVER_ERROR);
+        EnumSet<HttpStatus> getStatus = EnumSet.of(HttpStatus.SERVICE_UNAVAILABLE, HttpStatus.UNAUTHORIZED, HttpStatus.NOT_ACCEPTABLE, HttpStatus.EXPECTATION_FAILED, HttpStatus.INTERNAL_SERVER_ERROR, HttpStatus.UNPROCESSABLE_ENTITY);
 
         try {
-        	String generateUrl=generateURLTemplate.getUrl()+"&failIfMultipleFound="+failIfMultipleFound+"&failIfNoneFound="+failIfNoneFound+"&lookupInExternalERs="+lookupInExternalERs+"&lookupLimit="+lookupLimit;
+            String generateUrl=generateURLTemplate.getUrl()+"&failIfMultipleFound="+failIfMultipleFound+"&failIfNoneFound="+failIfNoneFound+"&lookupInExternalERs="+lookupInExternalERs+"&lookupLimit="+lookupLimit;
             ResponseEntity<String> response = restTemplate.postForEntity(generateUrl,
                     entity, String.class, generateURLTemplate.getMap(msgProtocol, msgType));
 

--- a/publish-service/src/test/java/com/ericsson/eiffel/remrem/publish/service/EiffelRemremCommonControllerUnitTest.java
+++ b/publish-service/src/test/java/com/ericsson/eiffel/remrem/publish/service/EiffelRemremCommonControllerUnitTest.java
@@ -173,15 +173,14 @@ public class EiffelRemremCommonControllerUnitTest {
 
     }
 
-
     @SuppressWarnings("unchecked")
     @Test
     public void testErLookupFailedWithOptions() throws Exception {
         String correctURL = "/{mp}?msgType={msgType}";
-        when(restTemplate.postForEntity(Mockito.contains(correctURL), Mockito.<HttpEntity<String>>any(),
+        when(restTemplate.postForEntity(Mockito.contains(correctURL), Mockito.<HttpEntity<String>> any(),
                 Mockito.eq(String.class), Mockito.anyMap())).thenReturn(responseOptionsFailed);
 
-        ResponseEntity<?> elem = unit.generateAndPublish("eiffelsemantics", "eiffelactivityfinished", "", "", "",false,
+        ResponseEntity<?> elem = unit.generateAndPublish("eiffelsemantics", "eiffelactivityfinished", "", "", "", false,
                 false, false, true, 1, body.getAsJsonObject());
         assertEquals(elem.getStatusCode(), HttpStatus.UNPROCESSABLE_ENTITY);
 
@@ -191,10 +190,10 @@ public class EiffelRemremCommonControllerUnitTest {
     @Test
     public void testErLookupFailedWithMultipleFound() throws Exception {
         String correctURL = "/{mp}?msgType={msgType}";
-        when(restTemplate.postForEntity(Mockito.contains(correctURL), Mockito.<HttpEntity<String>>any(),
+        when(restTemplate.postForEntity(Mockito.contains(correctURL), Mockito.<HttpEntity<String>> any(),
                 Mockito.eq(String.class), Mockito.anyMap())).thenReturn(responseMultipleFound);
 
-        ResponseEntity<?> elem = unit.generateAndPublish("eiffelsemantics", "eiffelactivityfinished", "", "", "",false,
+        ResponseEntity<?> elem = unit.generateAndPublish("eiffelsemantics", "eiffelactivityfinished", "", "", "", false,
                 false, false, true, 1, body.getAsJsonObject());
         assertEquals(elem.getStatusCode(), HttpStatus.EXPECTATION_FAILED);
 
@@ -204,10 +203,10 @@ public class EiffelRemremCommonControllerUnitTest {
     @Test
     public void testErLookupFailedWithNoneFound() throws Exception {
         String correctURL = "/{mp}?msgType={msgType}";
-        when(restTemplate.postForEntity(Mockito.contains(correctURL), Mockito.<HttpEntity<String>>any(),
+        when(restTemplate.postForEntity(Mockito.contains(correctURL), Mockito.<HttpEntity<String>> any(),
                 Mockito.eq(String.class), Mockito.anyMap())).thenReturn(responseNoneFound);
 
-        ResponseEntity<?> elem = unit.generateAndPublish("eiffelsemantics", "eiffelactivityfinished", "", "", "",false,
+        ResponseEntity<?> elem = unit.generateAndPublish("eiffelsemantics", "eiffelactivityfinished", "", "", "", false,
                 false, false, true, 1, body.getAsJsonObject());
         assertEquals(elem.getStatusCode(), HttpStatus.NOT_ACCEPTABLE);
 

--- a/publish-service/src/test/java/com/ericsson/eiffel/remrem/publish/service/EiffelRemremCommonControllerUnitTest.java
+++ b/publish-service/src/test/java/com/ericsson/eiffel/remrem/publish/service/EiffelRemremCommonControllerUnitTest.java
@@ -85,6 +85,15 @@ public class EiffelRemremCommonControllerUnitTest {
     @SuppressWarnings({ "rawtypes", "unchecked" })
     ResponseEntity responseBad = new ResponseEntity("ok", HttpStatus.BAD_REQUEST);
 
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    ResponseEntity responseOptionsFailed = new ResponseEntity("Link specific options could not be fulfilled", HttpStatus.UNPROCESSABLE_ENTITY);
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    ResponseEntity responseMultipleFound = new ResponseEntity("Muliple event ids found with ERLookup properties", HttpStatus.EXPECTATION_FAILED);
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    ResponseEntity responseNoneFound = new ResponseEntity("No event id found with ERLookup properties", HttpStatus.NOT_ACCEPTABLE);
+
     @Mock
     JsonElement body;
 
@@ -161,6 +170,46 @@ public class EiffelRemremCommonControllerUnitTest {
         assertEquals(mapTest.get("msgType"), map.get("msgType"));
 
         assertEquals(generateURLTemplate.getUrl(), correctURL);
+
+    }
+
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testErLookupFailedWithOptions() throws Exception {
+        String correctURL = "/{mp}?msgType={msgType}";
+        when(restTemplate.postForEntity(Mockito.contains(correctURL), Mockito.<HttpEntity<String>>any(),
+                Mockito.eq(String.class), Mockito.anyMap())).thenReturn(responseOptionsFailed);
+
+        ResponseEntity<?> elem = unit.generateAndPublish("eiffelsemantics", "eiffelactivityfinished", "", "", "",false,
+                false, false, true, 1, body.getAsJsonObject());
+        assertEquals(elem.getStatusCode(), HttpStatus.UNPROCESSABLE_ENTITY);
+
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testErLookupFailedWithMultipleFound() throws Exception {
+        String correctURL = "/{mp}?msgType={msgType}";
+        when(restTemplate.postForEntity(Mockito.contains(correctURL), Mockito.<HttpEntity<String>>any(),
+                Mockito.eq(String.class), Mockito.anyMap())).thenReturn(responseMultipleFound);
+
+        ResponseEntity<?> elem = unit.generateAndPublish("eiffelsemantics", "eiffelactivityfinished", "", "", "",false,
+                false, false, true, 1, body.getAsJsonObject());
+        assertEquals(elem.getStatusCode(), HttpStatus.EXPECTATION_FAILED);
+
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testErLookupFailedWithNoneFound() throws Exception {
+        String correctURL = "/{mp}?msgType={msgType}";
+        when(restTemplate.postForEntity(Mockito.contains(correctURL), Mockito.<HttpEntity<String>>any(),
+                Mockito.eq(String.class), Mockito.anyMap())).thenReturn(responseNoneFound);
+
+        ResponseEntity<?> elem = unit.generateAndPublish("eiffelsemantics", "eiffelactivityfinished", "", "", "",false,
+                false, false, true, 1, body.getAsJsonObject());
+        assertEquals(elem.getStatusCode(), HttpStatus.NOT_ACCEPTABLE);
 
     }
 

--- a/wiki/markdown/statusCodes.md
+++ b/wiki/markdown/statusCodes.md
@@ -170,6 +170,7 @@ These response can be generated only when `/generateAndPublish` endpoint is used
 | 401         | Unauthorized          | Unauthorized. Please, check if LDAP for REMReM Generate Service is disabled | Is returned if LDAP for REMReM Generate Service is enabled and REMReM Generate Publish have not access to it.          |
 | 406         | Not Acceptable        | No event id found with ERLookup properties                                  | Is returned if no event id fetched from configured event repository in REMReM generate.                                |
 | 417         | Expectation Failed    | Multiple event ids found with ERLookup properties                           | Is returned if multiple event ids fetched from configured event repository in REMReM generate.                         |
+| 422         | Unprocessable Entity  | Link specific options could not fetch information from ER                   | Is returned if could not fetch information from ER with specific options.                                              |
 | 500         | Internal Server Error | Internal server error in Generate Service                                   | Is returned if REMReM Generate Service is not started or in case of others internal errors in REMReM Generate Service. |
 | 503         | Service Unavailable   | Message protocol is invalid                                                 | Is returned if there is no such message protocol loaded.                                                               |
 
@@ -226,6 +227,19 @@ The Lookup properties with multiple event ids fetched from configured event repo
      "status_code": 417,
      "result": "FAIL",
      "message": "Multiple event ids found with ERLookup properties"
+    }
+]
+```
+
+**422 Unprocessable Entity**
+The link specific options could not fetch information from configured event repository in generate , REMReM fails to generate.
+
+```
+[
+    {
+     "status_code": 422,
+     "result": "FAIL",
+     "message": "Link specific options could not fetch information from ER"
     }
 ]
 ```

--- a/wiki/markdown/statusCodes.md
+++ b/wiki/markdown/statusCodes.md
@@ -170,7 +170,7 @@ These response can be generated only when `/generateAndPublish` endpoint is used
 | 401         | Unauthorized          | Unauthorized. Please, check if LDAP for REMReM Generate Service is disabled | Is returned if LDAP for REMReM Generate Service is enabled and REMReM Generate Publish have not access to it.          |
 | 406         | Not Acceptable        | No event id found with ERLookup properties                                  | Is returned if no event id fetched from configured event repository in REMReM generate.                                |
 | 417         | Expectation Failed    | Multiple event ids found with ERLookup properties                           | Is returned if multiple event ids fetched from configured event repository in REMReM generate.                         |
-| 422         | Unprocessable Entity  | Link specific options could not fetch information from ER                   | Is returned if could not fetch information from ER with specific options.                                              |
+| 422         | Unprocessable Entity  | Link specific lookup options could not be fulfilled                         | Is returned if Link specific lookup options could not be matched with failIfMultipleFound and failIfNoneFound.         |
 | 500         | Internal Server Error | Internal server error in Generate Service                                   | Is returned if REMReM Generate Service is not started or in case of others internal errors in REMReM Generate Service. |
 | 503         | Service Unavailable   | Message protocol is invalid                                                 | Is returned if there is no such message protocol loaded.                                                               |
 
@@ -232,14 +232,14 @@ The Lookup properties with multiple event ids fetched from configured event repo
 ```
 
 **422 Unprocessable Entity**
-The link specific options could not fetch information from configured event repository in generate , REMReM fails to generate.
+The link specific lookup options could not be matched with failIfMultipleFound and failIfNoneFound in generate , REMReM fails to generate.
 
 ```
 [
     {
      "status_code": 422,
      "result": "FAIL",
-     "message": "Link specific options could not fetch information from ER"
+     "message": "Link specific lookup options could not be fulfilled"
     }
 ]
 ```

--- a/wiki/markdown/usage.md
+++ b/wiki/markdown/usage.md
@@ -3,4 +3,4 @@ To get information about configuration and usage of REMReM Publish CLI see [here
 
 To get information about configuration and usage of REMReM Publish Service see [here](../markdown/usage/service.md).
 
-To get information about internal status codes see [here](statusCodes.md).
+To get information about internal status codes see [here](../markdown/statusCodes.md).

--- a/wiki/markdown/usage.md
+++ b/wiki/markdown/usage.md
@@ -3,4 +3,4 @@ To get information about configuration and usage of REMReM Publish CLI see [here
 
 To get information about configuration and usage of REMReM Publish Service see [here](../markdown/usage/service.md).
 
-To get information about internal status codes see [here](../markdown/statusCodes.md).
+To get information about internal status codes see [here](statusCodes.md).

--- a/wiki/markdown/usage/cli.md
+++ b/wiki/markdown/usage/cli.md
@@ -164,4 +164,4 @@ If CLI fails internally before trying to publish Eiffel message, user will get e
 ## Status Codes
 For each user request Eiffel REMReM Publish generate response in JSON with internal status code and message, when publishing takes place.
 
-To get information about internal status codes see [here](statusCodes.md).
+To get information about internal status codes see [here](../statusCodes.md).

--- a/wiki/markdown/usage/service.md
+++ b/wiki/markdown/usage/service.md
@@ -360,4 +360,4 @@ Result:
 ## Status Codes
 For each user request Eiffel REMReM Publish generate response in JSON with internal status code and message.
 
-To get information about internal status codes see [here](statusCodes.md).
+To get information about internal status codes see [here](../statusCodes.md).


### PR DESCRIPTION


<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->

### Description of the Change
REMReM lookups controlled 'failIfNoneFound' and 'failIfMultipleFound' lookups per lookup object within an event instead of globally per call.

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits
<!-- What benefits will be realized by the change? -->

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: <!-- <Your full name> <your-email@example.org> -->
