### PR TITLE
Added two external parameters to set username and password to connect to MB.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
   requests are sent to /generateAndPublish endpoint.
 - Uplifted eiffel-remrem-parent version from 2.0.4 to 2.0.5
 - Uplifted eiffel-remrem-shared version from 2.0.4 to 2.0.5
+- Added two external parameters to send username and password to connect to Messagebus.
+- Removed TLS Versions 1 and 1.1 as they are deprecated
 
 ## 2.0.19
 - Added the lenientValidation parameter(okToLeaveOutInvalidOptionalFields) for /generateAndPublish 

--- a/publish-cli/src/main/java/com/ericsson/eiffel/remrem/publish/cli/CliOptions.java
+++ b/publish-cli/src/main/java/com/ericsson/eiffel/remrem/publish/cli/CliOptions.java
@@ -76,13 +76,15 @@ public class CliOptions {
         options.addOption("np", "non_persistent", false, "remove persistence from message sending");
         options.addOption("port", "port", true, "port to connect to message bus, default is 5672");
         options.addOption("vh", "virtual_host", true, "virtual host to connect to (optional)");
-        options.addOption("tls", "tls", true, "tls version, specify a valid tls version: '1', '1.1, '1.2' or 'default'. It is required for RabbitMq secured port.");
+        options.addOption("tls", "tls", true, "tls version, specify a valid tls version: '1.2' or 'default'. It is required for RabbitMq secured port.");
         options.addOption("mp", "messaging_protocol", true, "name of messaging protocol to be used, e.g. eiffel3, eiffelsemantics, default is eiffelsemantics");
         options.addOption("domain", "domainId", true, "identifies the domain that produces the event");
         options.addOption("cc", "channelsCount", true, "Number of channels connected to message bus, default is 1");
         options.addOption("ud", "user_domain_suffix", true, "user domain suffix");
         options.addOption("v", "lists the versions of publish and all loaded protocols");
         options.addOption("tag", "tag", true, "tag to be used in routing key");
+        options.addOption("un", "username", true, "username to connect to message bus");
+        options.addOption("pwd", "password", true, "password to connect to message bus");
         options.addOption("rk", "routing_key", true, "routing key of the eiffel message. When provided routing key is not generated and the value provided is used.");
 
         contentGroup = createContentGroup();
@@ -225,13 +227,25 @@ public class CliOptions {
             String key = PropertiesConfig.CHANNELS_COUNT;
             System.setProperty(key, channelsCount);
         }
+ 
+        if (commandLine.hasOption("username")) {
+            String usernm = commandLine.getOptionValue("username");
+            String key = PropertiesConfig.USERNAME;
+            System.setProperty(key, usernm);
+        }
+
+        if (commandLine.hasOption("password")) {
+            String passwd = commandLine.getOptionValue("password");
+            String key = PropertiesConfig.PASSWORD;
+            System.setProperty(key, passwd);
+        }
 
         if (commandLine.hasOption("tls")) {
             String tls_ver = commandLine.getOptionValue("tls");
             if (tls_ver == null) {
                 tls_ver = "NULL";
             }
-            String[] validTlsVersions = new String[]{"1", "1.1", "1.2", "default"};
+            String[] validTlsVersions = new String[]{"1.2", "default"};
             if (!ArrayUtils.contains(validTlsVersions, tls_ver)) {
                 throw new HandleMessageBusException("Specified TLS version is not valid! Specify a valid TLS version!");
             }
@@ -273,6 +287,8 @@ public class CliOptions {
         System.clearProperty(PropertiesConfig.TLS);
         System.clearProperty(PropertiesConfig.DOMAIN_ID);
         System.clearProperty(PropertiesConfig.CHANNELS_COUNT);
+        System.clearProperty(PropertiesConfig.USERNAME);
+        System.clearProperty(PropertiesConfig.PASSWORD);
     }
 
     /**

--- a/publish-cli/src/test/java/com/ericsson/eiffel/remrem/publish/cli/CliOptionsUnitTests.java
+++ b/publish-cli/src/test/java/com/ericsson/eiffel/remrem/publish/cli/CliOptionsUnitTests.java
@@ -66,7 +66,7 @@ public class CliOptionsUnitTests {
 
     @Test
     public void testTlsOption() throws Exception {
-        String[] args = {"-f", "/a/b/c/test.file",  "test", "-tls", "1"};
+        String[] args = {"-f", "/a/b/c/test.file",  "test", "-tls", "1.2"};
         CliOptions.parse(args);
         assertTrue(CliOptions.getErrorCodes().isEmpty());
     }

--- a/publish-common/src/main/java/com/ericsson/eiffel/remrem/publish/config/PropertiesConfig.java
+++ b/publish-common/src/main/java/com/ericsson/eiffel/remrem/publish/config/PropertiesConfig.java
@@ -19,6 +19,8 @@ public class PropertiesConfig {
     public static final String MESSAGE_BUS_PORT = "com.ericsson.eiffel.remrem.publish.messagebus.port";
     public static final String VIRTUAL_HOST = "com.ericsson.eiffel.remrem.publish.messagebus.virtualhost";
     public static final String CHANNELS_COUNT = "com.ericsson.eiffel.remrem.publish.messagebus.channels";
+    public static final String USERNAME = "com.ericsson.eiffel.remrem.publish.messagebus.username";
+    public static final String PASSWORD = "com.ericsson.eiffel.remrem.publish.messagebus.password";
     public static final String TLS = "com.ericsson.eiffel.remrem.publish.messagebus.tls";
     public static final String EXCHANGE_NAME = "com.ericsson.eiffel.remrem.publish.exchange.name";
     public static final String USE_PERSISTENCE = "com.ericsson.eiffel.remrem.publish.use.persistence";

--- a/publish-common/src/main/java/com/ericsson/eiffel/remrem/publish/helper/RabbitMqProperties.java
+++ b/publish-common/src/main/java/com/ericsson/eiffel/remrem/publish/helper/RabbitMqProperties.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.TimeoutException;
@@ -284,11 +285,17 @@ public class RabbitMqProperties {
         port = Integer.getInteger(PropertiesConfig.MESSAGE_BUS_PORT);
         virtualHost = getValuesFromSystemProperties(PropertiesConfig.VIRTUAL_HOST);
         domainId = getValuesFromSystemProperties(PropertiesConfig.DOMAIN_ID);
+        username = getValuesFromSystemProperties(PropertiesConfig.USERNAME);
+        password = decryptString(getValuesFromSystemProperties(PropertiesConfig.PASSWORD));
         channelsCount = Integer.getInteger(PropertiesConfig.CHANNELS_COUNT);
         tlsVer = getValuesFromSystemProperties(PropertiesConfig.TLS);
         exchangeName = getValuesFromSystemProperties(PropertiesConfig.EXCHANGE_NAME);
         usePersitance = Boolean.getBoolean(PropertiesConfig.USE_PERSISTENCE);
         createExchangeIfNotExisting = Boolean.parseBoolean(getValuesFromSystemProperties(PropertiesConfig.CREATE_EXCHANGE_IF_NOT_EXISTING));
+    }
+
+    private String decryptString(String password) {
+        return new String(Base64.getDecoder().decode(password));
     }
 
     private String getValuesFromSystemProperties(String propertyName) {

--- a/publish-common/src/test/java/com/ericsson/eiffel/remrem/publish/helper/RMQHelperUnitTest.java
+++ b/publish-common/src/test/java/com/ericsson/eiffel/remrem/publish/helper/RMQHelperUnitTest.java
@@ -55,6 +55,8 @@ public class RMQHelperUnitTest {
     private static final String usePersistence= "1.2";
     private static final String domainId= "eiffelxxx";
     private static final Integer channelsCount= 1;
+    private static final String username= "guest";
+    private static final String password= "Z3Vlc3Q=";
     private String protocol = "eiffelsemantics";
     private String createExchange = "true";
 
@@ -97,6 +99,8 @@ public class RMQHelperUnitTest {
         System.setProperty(PropertiesConfig.CREATE_EXCHANGE_IF_NOT_EXISTING, createExchange);
         System.setProperty(PropertiesConfig.DOMAIN_ID, domainId);
         System.setProperty(PropertiesConfig.CHANNELS_COUNT, Integer.toString(channelsCount));
+        System.setProperty(PropertiesConfig.USERNAME, username);
+        System.setProperty(PropertiesConfig.PASSWORD, password);
     }
 
     private void cleanProperties() {
@@ -111,6 +115,8 @@ public class RMQHelperUnitTest {
         System.clearProperty(PropertiesConfig.CREATE_EXCHANGE_IF_NOT_EXISTING);
         System.clearProperty(PropertiesConfig.DOMAIN_ID);
         System.clearProperty(PropertiesConfig.CHANNELS_COUNT);
+        System.setProperty(PropertiesConfig.USERNAME, username);
+        System.setProperty(PropertiesConfig.PASSWORD, password);
     }
 
     @Test public void getHostTest() {
@@ -149,7 +155,7 @@ public class RMQHelperUnitTest {
     }
 
     @Test public void setTlsVersionTest() {
-        String tlsVersion = "1.1";
+        String tlsVersion = "1.2";
         rmqHelper.rabbitMqPropertiesMap.get(protocol).setTlsVer(tlsVersion);
         assertTrue(rmqHelper.rabbitMqPropertiesMap.get(protocol).getTlsVer().equals(tlsVersion));
     }
@@ -170,7 +176,7 @@ public class RMQHelperUnitTest {
         String host = "HOSTC";
         Integer portNumber = 1928;
         String virtHost = "/eiffel/test2";
-        String tlsVersion = "1.0";
+        String tlsVersion = "1.2";
         String exchangeNameTest = "EN2";
         String usePersistenceTest = "false";
 

--- a/wiki/markdown/usage/cli.md
+++ b/wiki/markdown/usage/cli.md
@@ -35,9 +35,14 @@ usage: java -jar
 -mp,--message_protocol <arg>      Name of messaging protocol to be used, e.g: eiffelsemantics.
                                   Default is eiffelsemantics.
 
+-un,--username <arg>              Username to connect to Messagebus
+
+-pwd,--password <arg>             Encrypted Password to connect to MessageBus. Plaintext password
+                                  should be encrypted using Base64 Encryption Mechanism.
+
 -np,--non_persistent              Remove persistence from message sending.
 
--tls,--tls <arg>                  tls version, specify a valid tls version: '1', '1.1', '1.2' or default.
+-tls,--tls <arg>                  tls version, specify a valid tls version: '1.2' or default.
                                   It is required for RabbitMQ secured port (5671).
 
 -port,--port <arg>                Port to connect to message bus, default is 5672.
@@ -66,19 +71,19 @@ Typical examples of usage Eiffel REMReM Publish CLI are described below.
 **Publish on a given host, given exchange, given domain and given user domain suffix:**
 
 ```
-java -jar publish-cli.jar -f publishMessages.json -en mb-exchange -mb hostname -domain publish-domain -ud messageQueue -mp eiffelsemantics
+java -jar publish-cli.jar -f publishMessages.json -en mb-exchange -mb hostname -domain publish-domain -ud messageQueue -mp eiffelsemantics -un username -pwd password
 ```
 
 **If you want to have the message non persistent add np flag:**
 
 ```
-java -jar publish-cli.jar -f publishMessages.json -en mb-exchange -mb hostname -domain publish-domain -np -mp eiffelsemantics
+java -jar publish-cli.jar -f publishMessages.json -en mb-exchange -mb hostname -domain publish-domain -np -mp eiffelsemantics -un username -pwd password 
 ```
 
 **For loading protocol jars other than eiffelsemantics:**
 
 ```
-java -Djava.ext.dirs="/path/to/jars/" -jar publish-cli.jar -f publishMessages.json -en mb-exchange -mb hostname -domain publish-domain -mp protocolType
+java -Djava.ext.dirs="/path/to/jars/" -jar publish-cli.jar -f publishMessages.json -en mb-exchange -mb hostname -domain publish-domain -mp protocolType -un username -pwd password
 ```
 
 **NOTE:** in the above example, protocol jar file must be present inside *"/path/to/jars/"* folder.
@@ -88,7 +93,7 @@ java -Djava.ext.dirs="/path/to/jars/" -jar publish-cli.jar -f publishMessages.js
 **If you want to have the message publishing logs add d flag:**
 
 ```
-java -jar publish-cli.jar -f publishMessages.json -en mb-exchange -mb hostname -domain publish-domain -mp eiffelsemantics -d
+java -jar publish-cli.jar -f publishMessages.json -en mb-exchange -mb hostname -domain publish-domain -mp eiffelsemantics -un username -pwd password -d
 ```
 
 **If you want to have the message publishing on RabbitMQ secured port (5671):**
@@ -96,7 +101,7 @@ java -jar publish-cli.jar -f publishMessages.json -en mb-exchange -mb hostname -
 -tls option value is either 'default' or <version> for secured port.
 
 ```
-java -jar publish-cli.jar -f publishMessages.json -en mb-exchange -mb hostname -domain publish-domain -mp eiffelsemantics -tls 1.2
+java -jar publish-cli.jar -f publishMessages.json -en mb-exchange -mb hostname -domain publish-domain -mp eiffelsemantics -un username -pwd password -tls 1.2
 ```
 
 **NOTE:** for RabbitMQ default port 5672, no need to pass -tls option.
@@ -104,7 +109,7 @@ java -jar publish-cli.jar -f publishMessages.json -en mb-exchange -mb hostname -
 **If you want to have the message publishing on RabbitMQ with given routing key:**
 
 ```
-java -jar publish-cli.jar -f publishMessages.json -en mb-exchange -mb hostname -domain publish-domain -mp eiffelsemantics -rk myroutingkey
+java -jar publish-cli.jar -f publishMessages.json -en mb-exchange -mb hostname -domain publish-domain -mp eiffelsemantics -rk myroutingkey -un username -pwd password
 ```
 
 **If you want to change the number of channels connected to RabbitMQ to publish messages:**
@@ -112,19 +117,19 @@ channelsCount default value is 1.
 If the number of channels increases then the CPU load and memory usage on the RabbitMq increases.
 
 ```
-java -jar publish-cli.jar -f publishMessages.json -en mb-exchange -mb hostname -domain publish-domain -mp eiffelsemantics -cc numberof-channels 
+java -jar publish-cli.jar -f publishMessages.json -en mb-exchange -mb hostname -domain publish-domain -mp eiffelsemantics -cc numberof-channels -un username -pwd password
 ```
 
 **If you want to have the message publishing on RabbitMQ with given tag:**
 
 ```
-java -jar publish-cli.jar -f publishMessages.json -en mb-exchange -mb hostname -domain publish-domain -mp eiffelsemantics -tag production
+java -jar publish-cli.jar -f publishMessages.json -en mb-exchange -mb hostname -domain publish-domain -mp eiffelsemantics -un username -pwd password -tag production
 ```
 
 **To create an exchange passed while publishing the messages use --create_exchange or -ce property to true. Example:**
 
 ```
-java -jar publish-cli.jar -f EiffelActivityStartedEvent.json -en mb-exchange -ce true -mb hostname -domain publish-domain -mp eiffelsemantics
+java -jar publish-cli.jar -f EiffelActivityStartedEvent.json -en mb-exchange -ce true -mb hostname -domain publish-domain -mp eiffelsemantics -un username -pwd password
 ```
 
 Output for these Example:


### PR DESCRIPTION
Removed TLS Versions 1 and 1.1 as they are deprecated


### Applicable Issues


### Description of the Change
As there was a requirement the 'guest' account was removed in some domains.
The TLS version is currently used to connect to secured port 5671. Earlier the TLS versions used are 1, 1.1 and 1.2. Now the TLS version 1 and 1.1 are depricated as they are considered insecure.
Therefore, configured two external parameters to send username and password to connect to Messagebus


### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits
Instead of using default login credentials, user can do secure authentication by using his credentails. Considered as more secure way.

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: <!-- Swathi Burada swathi.burada@tcs.com
