### PR TITLE
Implemented changes to handle the returning of duplicate eventId responses in Publish Response body.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Uplifted eiffel-remrem-parent version from 2.0.4 to 2.0.5
 - Uplifted eiffel-remrem-shared version from 2.0.4 to 2.0.5
 - Implemented changes and made the configurable parameter "virtualHost" as optional field.
+- Implemented changes to handle the returning of duplicate eventId responses in Publish Response body.
 
 ## 2.0.19
 - Added the lenientValidation parameter(okToLeaveOutInvalidOptionalFields) for /generateAndPublish 

--- a/publish-common/src/main/java/com/ericsson/eiffel/remrem/publish/service/MessageServiceRMQImpl.java
+++ b/publish-common/src/main/java/com/ericsson/eiffel/remrem/publish/service/MessageServiceRMQImpl.java
@@ -58,7 +58,7 @@ import ch.qos.logback.classic.Logger;
      * @see com.ericsson.eiffel.remrem.publish.service.MessageService#send(java.util.Map, java.util.Map)
      */
     @Override
-    public SendResult send(Map<String, String> routingKeyMap, Map<String, String> msgs, MsgService msgService) {
+    public synchronized SendResult send(Map<String, String> routingKeyMap, Map<String, String> msgs, MsgService msgService) {
         List<PublishResultItem> results = new CopyOnWriteArrayList<>();
         SendResult sendResult = null;
         PublishResultItem event = null;
@@ -85,7 +85,7 @@ import ch.qos.logback.classic.Logger;
      * @see com.ericsson.eiffel.remrem.publish.service.MessageService#send(java.lang.String, com.ericsson.eiffel.remrem.protocol.MsgService, java.lang.String)
      */
     @Override
-    public SendResult send(String jsonContent, MsgService msgService, String userDomainSuffix, String tag, String routingKey) {
+    public synchronized SendResult send(String jsonContent, MsgService msgService, String userDomainSuffix, String tag, String routingKey) {
 
         JsonParser parser = new JsonParser();
         try {
@@ -135,7 +135,7 @@ import ch.qos.logback.classic.Logger;
      * @see com.ericsson.eiffel.remrem.publish.service.MessageService#send(com.google.gson.JsonElement, com.ericsson.eiffel.remrem.protocol.MsgService, java.lang.String)
     */
     @Override
-    public SendResult send(JsonElement json, MsgService msgService, String userDomainSuffix, String tag, String routingKey) {
+    public synchronized SendResult send(JsonElement json, MsgService msgService, String userDomainSuffix, String tag, String routingKey) {
         Map<String, String> map = new HashMap<>();
         Map<String, String> routingKeyMap = new HashMap<>();
         SendResult result;
@@ -200,7 +200,7 @@ import ch.qos.logback.classic.Logger;
         return result;
     }
 
-    private String sendMessage(String routingKey, String msg, MsgService msgService) {
+    private synchronized String sendMessage(String routingKey, String msg, MsgService msgService) {
         String resultMsg = PropertiesConfig.SUCCESS;
         try {
             instantiateRmqHelper();

--- a/publish-common/src/main/java/com/ericsson/eiffel/remrem/publish/service/MessageServiceRMQImpl.java
+++ b/publish-common/src/main/java/com/ericsson/eiffel/remrem/publish/service/MessageServiceRMQImpl.java
@@ -58,7 +58,7 @@ import ch.qos.logback.classic.Logger;
      * @see com.ericsson.eiffel.remrem.publish.service.MessageService#send(java.util.Map, java.util.Map)
      */
     @Override
-    public synchronized SendResult send(Map<String, String> routingKeyMap, Map<String, String> msgs, MsgService msgService) {
+    public SendResult send(Map<String, String> routingKeyMap, Map<String, String> msgs, MsgService msgService) {
         List<PublishResultItem> results = new CopyOnWriteArrayList<>();
         SendResult sendResult = null;
         PublishResultItem event = null;
@@ -85,7 +85,7 @@ import ch.qos.logback.classic.Logger;
      * @see com.ericsson.eiffel.remrem.publish.service.MessageService#send(java.lang.String, com.ericsson.eiffel.remrem.protocol.MsgService, java.lang.String)
      */
     @Override
-    public synchronized SendResult send(String jsonContent, MsgService msgService, String userDomainSuffix, String tag, String routingKey) {
+    public SendResult send(String jsonContent, MsgService msgService, String userDomainSuffix, String tag, String routingKey) {
 
         JsonParser parser = new JsonParser();
         try {
@@ -135,7 +135,7 @@ import ch.qos.logback.classic.Logger;
      * @see com.ericsson.eiffel.remrem.publish.service.MessageService#send(com.google.gson.JsonElement, com.ericsson.eiffel.remrem.protocol.MsgService, java.lang.String)
     */
     @Override
-    public synchronized SendResult send(JsonElement json, MsgService msgService, String userDomainSuffix, String tag, String routingKey) {
+    public SendResult send(JsonElement json, MsgService msgService, String userDomainSuffix, String tag, String routingKey) {
         Map<String, String> map = new HashMap<>();
         Map<String, String> routingKeyMap = new HashMap<>();
         SendResult result;
@@ -200,7 +200,7 @@ import ch.qos.logback.classic.Logger;
         return result;
     }
 
-    private synchronized String sendMessage(String routingKey, String msg, MsgService msgService) {
+    private String sendMessage(String routingKey, String msg, MsgService msgService) {
         String resultMsg = PropertiesConfig.SUCCESS;
         try {
             instantiateRmqHelper();

--- a/publish-service/src/main/java/com/ericsson/eiffel/remrem/publish/controller/ProducerController.java
+++ b/publish-service/src/main/java/com/ericsson/eiffel/remrem/publish/controller/ProducerController.java
@@ -111,8 +111,10 @@ public class ProducerController {
                 return new ResponseEntity(e.getMessage(), HttpStatus.NOT_FOUND);
             }
         }
-        SendResult result = messageService.send(body, msgService, userDomain, tag, routingKey);
-        return new ResponseEntity(result, messageService.getHttpStatus());
+        synchronized(this) {
+            SendResult result = messageService.send(body, msgService, userDomain, tag, routingKey);
+            return new ResponseEntity(result, messageService.getHttpStatus());
+        }
     }
 
     /**
@@ -200,8 +202,10 @@ public class ProducerController {
                 if (msgService != null && msgProtocol != null) {
                     rmqHelper.rabbitMqPropertiesInit(msgProtocol);
                 }
-                SendResult result = messageService.send(responseBody, msgService, userDomain, tag, routingKey);
-                return new ResponseEntity(result, messageService.getHttpStatus());
+                synchronized(this) {
+                    SendResult result = messageService.send(responseBody, msgService, userDomain, tag, routingKey);
+                    return new ResponseEntity(result, messageService.getHttpStatus());
+                }
             } else {
                 return response;
             }

--- a/publish-service/src/main/java/com/ericsson/eiffel/remrem/publish/controller/ProducerController.java
+++ b/publish-service/src/main/java/com/ericsson/eiffel/remrem/publish/controller/ProducerController.java
@@ -110,9 +110,10 @@ public class ProducerController {
             } catch (RemRemPublishException e) {
                 return new ResponseEntity(e.getMessage(), HttpStatus.NOT_FOUND);
             }
+        } synchronized(this) {
+            SendResult result = messageService.send(body, msgService, userDomain, tag, routingKey);
+            return new ResponseEntity(result, messageService.getHttpStatus());
         }
-        SendResult result = messageService.send(body, msgService, userDomain, tag, routingKey);
-        return new ResponseEntity(result, messageService.getHttpStatus());
     }
 
     /**
@@ -200,8 +201,10 @@ public class ProducerController {
                 if (msgService != null && msgProtocol != null) {
                     rmqHelper.rabbitMqPropertiesInit(msgProtocol);
                 }
-                SendResult result = messageService.send(responseBody, msgService, userDomain, tag, routingKey);
-                return new ResponseEntity(result, messageService.getHttpStatus());
+                synchronized(this) {
+                    SendResult result = messageService.send(responseBody, msgService, userDomain, tag, routingKey);
+                    return new ResponseEntity(result, messageService.getHttpStatus());
+                }
             } else {
                 return response;
             }

--- a/publish-service/src/main/java/com/ericsson/eiffel/remrem/publish/controller/ProducerController.java
+++ b/publish-service/src/main/java/com/ericsson/eiffel/remrem/publish/controller/ProducerController.java
@@ -111,10 +111,8 @@ public class ProducerController {
                 return new ResponseEntity(e.getMessage(), HttpStatus.NOT_FOUND);
             }
         }
-        synchronized(this) {
-            SendResult result = messageService.send(body, msgService, userDomain, tag, routingKey);
-            return new ResponseEntity(result, messageService.getHttpStatus());
-        }
+        SendResult result = messageService.send(body, msgService, userDomain, tag, routingKey);
+        return new ResponseEntity(result, messageService.getHttpStatus());
     }
 
     /**
@@ -202,10 +200,8 @@ public class ProducerController {
                 if (msgService != null && msgProtocol != null) {
                     rmqHelper.rabbitMqPropertiesInit(msgProtocol);
                 }
-                synchronized(this) {
-                    SendResult result = messageService.send(responseBody, msgService, userDomain, tag, routingKey);
-                    return new ResponseEntity(result, messageService.getHttpStatus());
-                }
+                SendResult result = messageService.send(responseBody, msgService, userDomain, tag, routingKey);
+                return new ResponseEntity(result, messageService.getHttpStatus());
             } else {
                 return response;
             }


### PR DESCRIPTION


<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
https://github.com/eiffel-community/eiffel-remrem-publish/issues/217

### Description of the Change
REMReM in eiffel is returning 2 event-ids in body response when multiple events are sent. This results in eventId duplication in the Response body in Publish. 
Implemented Synchronization in /generateAndPublish and /producer/msg endpoints so that the process executes in sync.

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits
When multiple events are published at a time, there will be no duplication in the eventId response in the Response body in  publish service.

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Swathi Burada swathi.burada@tcs.com
