### PR TITLE
Make Jasypt configuration optional

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>2.0.5</version>
     </parent>
     <properties>
-        <eiffel-remrem-publish.version>2.0.21</eiffel-remrem-publish.version>
+        <eiffel-remrem-publish.version>2.0.22</eiffel-remrem-publish.version>
         <eiffel-remrem-shared.version>2.0.5</eiffel-remrem-shared.version>
         <eiffel-remrem-semantics.version>2.0.13</eiffel-remrem-semantics.version>
     </properties>

--- a/publish-common/pom.xml
+++ b/publish-common/pom.xml
@@ -113,11 +113,17 @@
             <version>2.4.0</version>
             <scope>compile</scope>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind --> 
+        <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind -->
         <dependency>
-           <groupId>com.fasterxml.jackson.core</groupId>
-           <artifactId>jackson-databind</artifactId>
-           </dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.13.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.13.0</version>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/publish-common/src/main/java/com/ericsson/eiffel/remrem/publish/config/RabbitMqPropertiesConfig.java
+++ b/publish-common/src/main/java/com/ericsson/eiffel/remrem/publish/config/RabbitMqPropertiesConfig.java
@@ -48,10 +48,10 @@ public class RabbitMqPropertiesConfig {
     @Autowired
     Environment env;
 
-    @Value("${rabbitmq.instances.jsonlist:{null}}")
+    @Value("${rabbitmq.instances.jsonlist:#{null}}")
     private String rabbitmqInstancesJsonListContent;
 
-    @Value("${jasypt.encryptor.jasyptKeyFilePath:{null}}")
+    @Value("${jasypt.encryptor.jasyptKeyFilePath:#{null}}")
     private String jasyptKeyFilePath;
 
     private Map<String, RabbitMqProperties> rabbitMqPropertiesMap = new HashMap<String, RabbitMqProperties>();
@@ -80,8 +80,12 @@ public class RabbitMqPropertiesConfig {
      */
     private void readSpringProperties() {
         JsonNode rabbitmqInstancesJsonListJsonArray = null;
+        String jasyptKey = null;
         final ObjectMapper objMapper = new ObjectMapper();
-        final String jasyptKey = readJasyptKeyFile(jasyptKeyFilePath);
+        if (jasyptKeyFilePath != null && !jasyptKeyFilePath.equals("\"\"")) {
+            log.info("Initiating Jasypt Key File");
+            jasyptKey = readJasyptKeyFile(jasyptKeyFilePath);
+        }
 
         try {
             rabbitmqInstancesJsonListJsonArray = objMapper.readTree(rabbitmqInstancesJsonListContent);
@@ -101,8 +105,11 @@ public class RabbitMqPropertiesConfig {
                 String rabbitMqPassword = rabbitmqInstanceObject.get("password").asText();
                 if (rabbitMqPassword.startsWith("{ENC(") && rabbitMqPassword.endsWith("}")) {
                     rabbitMqPassword = rabbitMqPassword.substring(1, rabbitMqPassword.length() - 1);
+                    rabbitMqProperties.setPassword(DecryptionUtils.decryptString(rabbitMqPassword, jasyptKey));
                 }
-                rabbitMqProperties.setPassword(DecryptionUtils.decryptString(rabbitMqPassword, jasyptKey));
+                else{
+                    rabbitMqProperties.setPassword(rabbitMqPassword);
+                }
                 rabbitMqProperties.setTlsVer(rabbitmqInstanceObject.get("tls").asText());
                 rabbitMqProperties.setExchangeName(rabbitmqInstanceObject.get("exchangeName").asText());
                 rabbitMqProperties.setCreateExchangeIfNotExisting(rabbitmqInstanceObject.get("createExchangeIfNotExisting").asBoolean());

--- a/publish-common/src/main/java/com/ericsson/eiffel/remrem/publish/config/RabbitMqPropertiesConfig.java
+++ b/publish-common/src/main/java/com/ericsson/eiffel/remrem/publish/config/RabbitMqPropertiesConfig.java
@@ -82,7 +82,7 @@ public class RabbitMqPropertiesConfig {
         JsonNode rabbitmqInstancesJsonListJsonArray = null;
         String jasyptKey = null;
         final ObjectMapper objMapper = new ObjectMapper();
-        if (jasyptKeyFilePath != null && !jasyptKeyFilePath.equals("\"\"")) {
+        if (jasyptKeyFilePath != null && !jasyptKeyFilePath.equals("\"\"") && !jasyptKeyFilePath.equals("''")) {
             log.info("Initiating Jasypt Key File");
             jasyptKey = readJasyptKeyFile(jasyptKeyFilePath);
         }


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
Fails to startup and read provided configuration(without Jasypt property) due to mandatory Jasypt configuration which should be optional.

### Description of the Change
This change make the Jasypt configuration optional and do not fail at startup on reading provided application properties.
There were also Jackson library issues in produced publish-service.war artifact that is generated by maven package goal which failed the execution of publish-service.war and service never starts.
Publish-Service.war is the released artifact to JitPack for every GitHub release, so this artifact should be tested and kept in a functional state.

#222

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits
Fully functional RemRem-Publish application without any requirements on Jasypt configuration.
Fixes Jackson Library exception in publish-service.war artifact, which is released and executed by the end-user.

### Possible Drawbacks
No

### Sign-off
tobias.akervik@ericsson.com

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: <!-- <Your full name> <your-email@example.org> -->
