### PR TITLE
Added code changes so that REMReM Publish should not die even

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.0.25
 - Implemented "publisher confirms " in REMReM so that this  can be used to get confirmation about the messages sent to MB.
 - Implemented configurable parameters for TCP connection timeout against LDAP and MB
+- Added code changes so that REMReM Publish should not die if RabbitMQ is unavailable when starting up.
 
 ## 2.0.24
 - Updated all the curl commands in documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
+## 2.0.26
+- Added code changes so that REMReM Publish should not die if RabbitMQ is unavailable when starting up.
+
 ## 2.0.25
 - Implemented "publisher confirms " in REMReM so that this  can be used to get confirmation about the messages sent to MB.
 - Implemented configurable parameters for TCP connection timeout against LDAP and MB
 - Implemented changes to return proper error messages when DomainId value is greater than 255 chars.
-- Added code changes so that REMReM Publish should not die if RabbitMQ is unavailable when starting up.
 
 ## 2.0.24
 - Updated all the curl commands in documentation

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>2.0.8</version>
     </parent>
     <properties>
-        <eiffel-remrem-publish.version>2.0.25</eiffel-remrem-publish.version>
+        <eiffel-remrem-publish.version>2.0.26</eiffel-remrem-publish.version>
         <eiffel-remrem-semantics.version>2.2.3</eiffel-remrem-semantics.version>
     </properties>
     <artifactId>eiffel-remrem-publish</artifactId>

--- a/publish-common/src/main/java/com/ericsson/eiffel/remrem/publish/exception/RemRemPublishException.java
+++ b/publish-common/src/main/java/com/ericsson/eiffel/remrem/publish/exception/RemRemPublishException.java
@@ -14,6 +14,8 @@
 */
 package com.ericsson.eiffel.remrem.publish.exception;
 
+import com.ericsson.eiffel.remrem.publish.helper.RMQBeanConnectionFactory;
+
 public class RemRemPublishException extends Exception {
 
     private static final long serialVersionUID = 1L;
@@ -21,7 +23,13 @@ public class RemRemPublishException extends Exception {
     public RemRemPublishException(String message) {
         super(message);
     }
-    public RemRemPublishException(String message , Throwable cause) {
+
+    public RemRemPublishException(String message, Throwable cause) {
         super(message, cause);
+    }
+
+    public RemRemPublishException(String message, RMQBeanConnectionFactory factory,
+            Throwable cause) {
+        super(message + factory.getHost() + ":" + factory.getPort(), cause);
     }
 }

--- a/publish-common/src/main/java/com/ericsson/eiffel/remrem/publish/exception/RemRemPublishException.java
+++ b/publish-common/src/main/java/com/ericsson/eiffel/remrem/publish/exception/RemRemPublishException.java
@@ -21,4 +21,7 @@ public class RemRemPublishException extends Exception {
     public RemRemPublishException(String message) {
         super(message);
     }
+    public RemRemPublishException(String message , Throwable cause) {
+        super(message, cause);
+    }
 }

--- a/publish-common/src/main/java/com/ericsson/eiffel/remrem/publish/helper/RabbitMqProperties.java
+++ b/publish-common/src/main/java/com/ericsson/eiffel/remrem/publish/helper/RabbitMqProperties.java
@@ -89,15 +89,10 @@ public class RabbitMqProperties {
     }
 
     public void setExchangeName(String exchangeName) {
-        this.exchangeName = exchangeName;
-    }
-
-    public boolean getHasExchange() {
-        return hasExchange;
-    }
-
-    public void setHasExchange(boolean hasExchange) {
-        this.hasExchange = hasExchange;
+        if (!exchangeName.equals(this.exchangeName)) {
+            this.exchangeName = exchangeName;
+            this.hasExchange = false;
+        }
     }
 
     public Integer getPort() {
@@ -279,7 +274,8 @@ public class RabbitMqProperties {
             }
         } catch (IOException | TimeoutException e) {
             log.error(e.getMessage(), e);
-            throw new RemRemPublishException("Failed to create connection for Rabbitmq ::" + factory.getHost() + ":" + factory.getPort(), e);
+            throw new RemRemPublishException("Failed to create connection for Rabbitmq ::", factory,
+                    e);
         }
     }
 
@@ -379,21 +375,26 @@ public class RabbitMqProperties {
                 try {
                     connection = factory.newConnection();
                 } catch (final IOException | TimeoutException e) {
-                    throw new RemRemPublishException("Exception occurred while creating Rabbitmq connection ::" + factory.getHost() + ":" + factory.getPort() + e.getMessage(), e);
+                    throw new RemRemPublishException(
+                            "Exception occurred while creating Rabbitmq connection ::", factory, e);
                 }
                 Channel channel = null;
                 try {
                     channel = connection.createChannel();
                 } catch (final IOException e) {
-                    throw new RemRemPublishException("Exception occurred while creating Channel with Rabbitmq connection ::" + factory.getHost() + ":" + factory.getPort() + e.getMessage(), e);
+                    throw new RemRemPublishException(
+                            "Exception occurred while creating Channel with Rabbitmq connection ::",
+                            factory, e);
                 }
                 try {
                     channel.exchangeDeclare(exchangeName, "topic", true);
-                    log.info("Exchange "+exchangeName+" is created");
+                    log.info("Exchange {} is created",exchangeName);
                     hasExchange = true;
                 } catch (final IOException e) {
                     log.info(exchangeName + "failed to create an exchange");
-                    throw new RemRemPublishException("Unable to create Exchange with Rabbitmq connection " + exchangeName + factory.getHost() + ":" + factory.getPort() + e.getMessage(), e);
+                    throw new RemRemPublishException(
+                            "Unable to create exchange with Rabbitmq connection " + exchangeName,
+                            factory, e);
                 } finally {
                     if (channel == null || channel.isOpen()) {
                         try {
@@ -423,7 +424,7 @@ public class RabbitMqProperties {
      */
     private boolean hasExchange() throws RemRemPublishException {
         if(hasExchange) {
-           log.info("Exchange is: " + exchangeName);
+           log.info("Exchange is:{} ", exchangeName);
            return true;
         }
 
@@ -431,13 +432,16 @@ public class RabbitMqProperties {
         try {
             connection = factory.newConnection();
         } catch (final IOException | TimeoutException e) {
-            throw new RemRemPublishException("Exception occurred while creating Rabbitmq connection ::" + factory.getHost() + ":" + factory.getPort() + e.getMessage(), e);
+            throw new RemRemPublishException(
+                    "Exception occurred while creating Rabbitmq connection ::", factory, e);
         }
         Channel channel = null;
         try {
             channel = connection.createChannel();
         } catch (final IOException e) {
-            throw new RemRemPublishException("Exception occurred while creating Channel with Rabbitmq connection ::" + factory.getHost() + ":" + factory.getPort() + e.getMessage(), e);
+            throw new RemRemPublishException(
+                    "Exception occurred while creating Channel with Rabbitmq connection ::",
+                    factory, e);
         }
         try {
             channel.exchangeDeclarePassive(exchangeName);
@@ -510,7 +514,8 @@ public class RabbitMqProperties {
         } catch (Exception e) {
             log.error(e.getMessage(), e);
             if(!channel.isOpen()&& rabbitConnection.isOpen()){
-                throw new RemRemPublishException("Channel was closed for Rabbitmq connection ::" + factory.getHost() + ":" + factory.getPort() + e.getMessage(), e);
+                throw new RemRemPublishException("Channel was closed for Rabbitmq connection ::",
+                        factory, e);
             }
             throw new IOException("Failed to publish message due to " + e.getMessage(), e);
         }

--- a/publish-common/src/main/java/com/ericsson/eiffel/remrem/publish/helper/RabbitMqProperties.java
+++ b/publish-common/src/main/java/com/ericsson/eiffel/remrem/publish/helper/RabbitMqProperties.java
@@ -489,7 +489,7 @@ public class RabbitMqProperties {
         } catch (Exception e) {
             log.error(e.getMessage(), e);
             if(!channel.isOpen()&& rabbitConnection.isOpen()){
-                throw new RemRemPublishException("Channel was closed for Rabbitmq connection ::" + factory.getHost() + factory.getPort()+" due to "+e.getMessage());
+                throw new RemRemPublishException("Channel was closed for Rabbitmq connection ::" + factory.getHost() + factory.getPort() + e.getMessage());
             }
             throw new IOException("Failed to publish message due to " + e.getMessage());
         }

--- a/publish-common/src/main/java/com/ericsson/eiffel/remrem/publish/helper/RabbitMqProperties.java
+++ b/publish-common/src/main/java/com/ericsson/eiffel/remrem/publish/helper/RabbitMqProperties.java
@@ -183,7 +183,7 @@ public class RabbitMqProperties {
         this.rabbitConnection = rabbitConnection;
     }
 
-    public void init() throws RemRemPublishException {
+    public void init() {
         log.info("RabbitMqProperties init ...");
         if (Boolean.getBoolean(PropertiesConfig.CLI_MODE)) {
             initCli();
@@ -238,7 +238,12 @@ public class RabbitMqProperties {
         } catch (NoSuchAlgorithmException e) {
             log.error(e.getMessage(), e);            
         }
-        checkAndCreateExchangeIfNeeded();
+        try {
+            checkAndCreateExchangeIfNeeded();
+        } catch (RemRemPublishException e) {
+            log.error("Error occured while setting up the RabbitMq Connection. "+e.getMessage());
+            e.printStackTrace();
+        }
     }
 
     /**
@@ -484,7 +489,7 @@ public class RabbitMqProperties {
         } catch (Exception e) {
             log.error(e.getMessage(), e);
             if(!channel.isOpen()&& rabbitConnection.isOpen()){
-                throw new RemRemPublishException("Channel was closed for Rabbitmq connection ::" + factory.getHost() + factory.getPort());
+                throw new RemRemPublishException("Channel was closed for Rabbitmq connection ::" + factory.getHost() + factory.getPort()+" due to "+e.getMessage());
             }
             throw new IOException("Failed to publish message due to " + e.getMessage());
         }

--- a/publish-common/src/main/java/com/ericsson/eiffel/remrem/publish/helper/RabbitMqProperties.java
+++ b/publish-common/src/main/java/com/ericsson/eiffel/remrem/publish/helper/RabbitMqProperties.java
@@ -274,7 +274,7 @@ public class RabbitMqProperties {
             }
         } catch (IOException | TimeoutException e) {
             log.error(e.getMessage(), e);
-            throw new RemRemPublishException("Failed to create connection for Rabbitmq ::", factory,
+            throw new RemRemPublishException("Failed to create connection for Rabbitmq :: ", factory,
                     e);
         }
     }
@@ -376,7 +376,7 @@ public class RabbitMqProperties {
                     connection = factory.newConnection();
                 } catch (final IOException | TimeoutException e) {
                     throw new RemRemPublishException(
-                            "Exception occurred while creating Rabbitmq connection ::", factory, e);
+                            "Exception occurred while creating Rabbitmq connection :: ", factory, e);
                 }
                 Channel channel = null;
                 try {
@@ -393,7 +393,7 @@ public class RabbitMqProperties {
                 } catch (final IOException e) {
                     log.info(exchangeName + "failed to create an exchange");
                     throw new RemRemPublishException(
-                            "Unable to create exchange with Rabbitmq connection " + exchangeName,
+                            "Unable to create Exchange with Rabbitmq connection " + exchangeName,
                             factory, e);
                 } finally {
                     if (channel == null || channel.isOpen()) {
@@ -424,7 +424,7 @@ public class RabbitMqProperties {
      */
     private boolean hasExchange() throws RemRemPublishException {
         if(hasExchange) {
-           log.info("Exchange is:{} ", exchangeName);
+           log.info("Exchange is: {}", exchangeName);
            return true;
         }
 
@@ -433,14 +433,14 @@ public class RabbitMqProperties {
             connection = factory.newConnection();
         } catch (final IOException | TimeoutException e) {
             throw new RemRemPublishException(
-                    "Exception occurred while creating Rabbitmq connection ::", factory, e);
+                    "Exception occurred while creating Rabbitmq connection :: ", factory, e);
         }
         Channel channel = null;
         try {
             channel = connection.createChannel();
         } catch (final IOException e) {
             throw new RemRemPublishException(
-                    "Exception occurred while creating Channel with Rabbitmq connection ::",
+                    "Exception occurred while creating Channel with Rabbitmq connection :: ",
                     factory, e);
         }
         try {
@@ -514,7 +514,7 @@ public class RabbitMqProperties {
         } catch (Exception e) {
             log.error(e.getMessage(), e);
             if(!channel.isOpen()&& rabbitConnection.isOpen()){
-                throw new RemRemPublishException("Channel was closed for Rabbitmq connection ::",
+                throw new RemRemPublishException("Channel was closed for Rabbitmq connection :: ",
                         factory, e);
             }
             throw new IOException("Failed to publish message due to " + e.getMessage(), e);

--- a/publish-service/src/test/java/com/ericsson/eiffel/remrem/publish/service/MessageServiceRMQImplUnitTest.java
+++ b/publish-service/src/test/java/com/ericsson/eiffel/remrem/publish/service/MessageServiceRMQImplUnitTest.java
@@ -86,12 +86,12 @@ public class MessageServiceRMQImplUnitTest {
      * exchange it will throw an Exception.
      */
     @Test
-    public void testCreateExchangeIfNotExistingEnable() throws RemRemPublishException {
+    public void testCreateExchangeIfNotExistingEnable() {
         boolean ExceptionOccured = false;
         rabbitmqProtocolProperties.setExchangeName("nonexistexchangename");
         rabbitmqProtocolProperties.setCreateExchangeIfNotExisting(createExchangeIfNotExisting);
         try {
-            rabbitmqProtocolProperties.init();
+            rabbitmqProtocolProperties.checkAndCreateExchangeIfNeeded();
         } catch (RemRemPublishException e) {
             ExceptionOccured = true;
         } finally {
@@ -110,7 +110,7 @@ public class MessageServiceRMQImplUnitTest {
     public void testCreateExchangeIfNotExistingDisable() throws RemRemPublishException  {
         rabbitmqProtocolProperties.setExchangeName("test76888");
         rabbitmqProtocolProperties.setCreateExchangeIfNotExisting(false);
-        rabbitmqProtocolProperties.init();
+        rabbitmqProtocolProperties.checkAndCreateExchangeIfNeeded();
 
         rabbitmqProtocolProperties.setExchangeName(exchangeName);
         rabbitmqProtocolProperties.init();

--- a/publish-service/src/test/java/com/ericsson/eiffel/remrem/publish/service/MessageServiceRMQImplUnitTest.java
+++ b/publish-service/src/test/java/com/ericsson/eiffel/remrem/publish/service/MessageServiceRMQImplUnitTest.java
@@ -108,7 +108,6 @@ public class MessageServiceRMQImplUnitTest {
      */
     @Test(expected = RemRemPublishException.class)
     public void testCreateExchangeIfNotExistingDisable() throws RemRemPublishException  {
-        rabbitmqProtocolProperties.setHasExchange(false);
         rabbitmqProtocolProperties.setExchangeName("test76888");
         rabbitmqProtocolProperties.setCreateExchangeIfNotExisting(false);
         rabbitmqProtocolProperties.checkAndCreateExchangeIfNeeded();

--- a/publish-service/src/test/java/com/ericsson/eiffel/remrem/publish/service/MessageServiceRMQImplUnitTest.java
+++ b/publish-service/src/test/java/com/ericsson/eiffel/remrem/publish/service/MessageServiceRMQImplUnitTest.java
@@ -108,6 +108,7 @@ public class MessageServiceRMQImplUnitTest {
      */
     @Test(expected = RemRemPublishException.class)
     public void testCreateExchangeIfNotExistingDisable() throws RemRemPublishException  {
+        rabbitmqProtocolProperties.setHasExchange(false);
         rabbitmqProtocolProperties.setExchangeName("test76888");
         rabbitmqProtocolProperties.setCreateExchangeIfNotExisting(false);
         rabbitmqProtocolProperties.checkAndCreateExchangeIfNeeded();

--- a/publish-service/src/test/java/com/ericsson/eiffel/remrem/publish/service/MessageServiceRMQImplUnitTest.java
+++ b/publish-service/src/test/java/com/ericsson/eiffel/remrem/publish/service/MessageServiceRMQImplUnitTest.java
@@ -87,18 +87,18 @@ public class MessageServiceRMQImplUnitTest {
      */
     @Test
     public void testCreateExchangeIfNotExistingEnable() {
-        boolean ExceptionOccured = false;
+        boolean exceptionOccured = false;
         rabbitmqProtocolProperties.setExchangeName("nonexistexchangename");
         rabbitmqProtocolProperties.setCreateExchangeIfNotExisting(createExchangeIfNotExisting);
         try {
             rabbitmqProtocolProperties.checkAndCreateExchangeIfNeeded();
         } catch (RemRemPublishException e) {
-            ExceptionOccured = true;
+            exceptionOccured = true;
         } finally {
             rabbitmqProtocolProperties.setExchangeName(exchangeName);
             rabbitmqProtocolProperties.init();
         }
-        assertFalse("An exception occured while creating a exchange", ExceptionOccured);
+        assertFalse("An exception occured while creating a exchange", exceptionOccured);
     }
 
     /**


### PR DESCRIPTION
Added code changes so that REMReM Publish will not die if RabbitMQ is unavailable when starting up

<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
https://github.com/eiffel-community/eiffel-remrem-publish/issues/179

### Description of the Change
Made code changes so that REMReM publish  will not die even though RabbitMq is unavailable when starting up the service

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits
<!-- What benefits will be realized by the change? -->

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Vaishnavi Enugala vaishnavi.enugala@tcs.com 
