### PR TITLE
Fix overriding semantics messaging version in newer openjdk 8 versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Visit [Eiffel Community](https://eiffel-community.github.io) to get started and 
 2. [**Installation**](wiki/markdown/installation.md)
 
 3. [**Running RemRem-Publish service**](wiki/markdown/running-remrem-publish.md)
+    - [**Run Application**](wiki/markdown/run.md)
     - [**Run in Docker**](wiki/markdown/docker.md)
     - [**Configuration**](wiki/markdown/configuration.md)
     

--- a/publish-service/src/main/java/com/ericsson/eiffel/remrem/publish/controller/VersionService.java
+++ b/publish-service/src/main/java/com/ericsson/eiffel/remrem/publish/controller/VersionService.java
@@ -79,7 +79,9 @@ public class VersionService {
                             if (version != null) {
                                 
                                 if (mainAttribs.getValue(IS_ENDPOINT_VERSION) != null) {
-                                    endpointVersions.put(versionKey, version);
+                                    if(endpointVersions.get(versionKey) == null) {
+                                        endpointVersions.put(versionKey, version);
+                                    }
                                 } else {
                                     serviceVersion.put(versionKey, version);
                                 }

--- a/wiki/markdown/run.md
+++ b/wiki/markdown/run.md
@@ -12,7 +12,7 @@ RemRem-Publish application can be executed with Maven command or with the maven 
 1. Change to service directory: 
 `cd publish-service`
 
-2. Execute maven command to build and run RemRem-Generate:
+2. Execute maven command to build and run RemRem-Publish:
 `mvn spring-boot:run`
 
 
@@ -37,7 +37,7 @@ Provide customized RemRem-Publish application.properties configuration via the s
 `-Dspring.config.location=/path/to/application.properties`
 
 
-## Override RemRem-Generate Eiffel Protocol Version
+## Override RemRem-Publish Eiffel Protocol Version
 
 Eiffel-RemRem Protocol versions is developed and released by Github project:
 https://github.com/eiffel-community/eiffel-remrem-semantics

--- a/wiki/markdown/run.md
+++ b/wiki/markdown/run.md
@@ -1,0 +1,61 @@
+# Run RemRem-Publish Applciation
+
+RemRem-Publish application can be executed with Maven command or with the maven built war file.
+
+## Requirements
+
+- Java
+- Maven
+
+## Run RemRem-Publish With Maven Command
+
+1. Change to service directory: 
+`cd publish-service`
+
+2. Execute maven command to build and run RemRem-Generate:
+`mvn spring-boot:run`
+
+
+## Run RemRem-Publish With Java Command
+
+1. Go to RemRem-Publish git root directory
+
+2. Execute maven package command to build the RemRem-Publish war file:
+`mvn package -DskipTests`
+
+This will produce a war file in the "target" folder.
+The RemRem-Publish released war file can be downloaded from JitPack.
+
+3. Run RemRem-Publish application war file
+There is some alternatives to execute the war file with java command.
+`java -classpath publish-service/target/publish-service-2.0.26.war org.springframework.boot.loader.WarLauncher`
+or
+`java -jar publish-service/target/publish-service-2.0.26.war`
+
+
+Provide customized RemRem-Publish application.properties configuration via the spring.config.location java flag which need to be appended to the java command line:
+`-Dspring.config.location=/path/to/application.properties`
+
+
+## Override RemRem-Generate Eiffel Protocol Version
+
+Eiffel-RemRem Protocol versions is developed and released by Github project:
+https://github.com/eiffel-community/eiffel-remrem-semantics
+
+Eiffel-RemRem-Semantic versions is released in Jitpack and can be downloaded as jar file.
+Eiffel-Remrem-Semantic releases version jar files:
+https://jitpack.io/com/github/eiffel-community/eiffel-remrem-semantics
+
+Example of one Eiffel-Semantic-version Jitpack download url address:
+https://jitpack.io/com/github/eiffel-community/eiffel-remrem-semantics/2.2.1/eiffel-remrem-semantics-2.2.1.jar
+
+Eiffel-RemRem-Publish is released with a built-in eiffel-semantic protocol version which can be overridden with a different eiffel-semantic version by adding the external eiffel-semantic version jar file to classpath.
+
+Execute RemRem-Publish application with external eiffel-semantic version jar file to classpath:
+`java -classpath /path/to/protocol/eiffel-remrem-semantics-2.2.2.jar:publish-service/target/publish-service-2.0.26.war org.springframework.boot.loader.WarLauncher`
+
+Another alternative (works only with Java 8):
+`java -Djava.ext.dirs=/path/to/protocol/eiffel-remrem-semantics-2.2.2.jar -jar publish-service/target/publish-service-2.0.26.war`
+
+Go to http://localhost:8080/versions and "semanticsVersion" field should show the overridden eiffel-semantic version.
+


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
In later java 8 version class is loaded in reversed order and if external eiffel-semantic version jar files are provided then internal built-in eiffel-semantic version is used.
External eiffel-semantic version is configured with java flag:
java -Djava.ext.dirs=/path/to/eiffel-semantic-jar-files-dir/ -jar /path/to/generate-service-x.y.z.war

-Djava.ext.dirs is deprecated in Java 8 since many years ago and the -classpath should be used in newer Java versions, example:
java -classpath "/path/to/eiffel-semantic-protocol-jars/*:publish-service/target/publish-service-2.0.26.war" org.springframework.boot.loader.WarLaunch

### Description of the Change
Change so external provided eiffel-semantic version is used if provided with "-Djava.ext.dirs".


### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits
<!-- What benefits will be realized by the change? -->

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: <!-- <Your full name> <your-email@example.org> -->
