### PR TITLE
Dockerfile still references JDK 8

### DIFF
--- a/publish-service/src/main/docker/Dockerfile
+++ b/publish-service/src/main/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM tomcat:8.0-jre8
+FROM tomcat:9.0.58-jdk17-openjdk-slim
 MAINTAINER Eiffel-Community
 ARG URL
 RUN echo Building RemRem-Publish image based on artifact url: ${URL}

--- a/wiki/markdown/index.md
+++ b/wiki/markdown/index.md
@@ -16,3 +16,20 @@ For supporting latest features, Eiffel REMReM Publish should use the latest vers
 
 *   REMReM Publish CLI (Command Line Interface)
 *   REMReM Publish Service
+
+## Compatibility
+Both [`generate`](https://github.com/eiffel-community/eiffel-remrem-generate) and `publish` services use [`semantics`](https://github.com/eiffel-community/eiffel-remrem-semantics) library. Below is compatibility table of particular versions.
+| `semantics` | `generate`          | `publish`           |
+|-------------|---------------------|---------------------|
+| `2.0.3`     | `2.0.2`             | `2.0.0`             |
+| `2.0.4`     | `2.0.3`             | `2.0.1`             |
+| `2.0.5`     | `2.0.4`             | `2.0.2` - `2.0.5`   |
+| `2.0.6`     | `2.0.5` - `2.0.9`   | `2.0.6` - `2.0.9`   |
+| `2.0.7`     |                     | `2.0.10`            |
+| `2.0.8`     | `2.0.10`            | `2.0.11`            |
+| `2.0.9`     | `2.0.11`            | `2.0.12`            |
+| `2.0.11`    |                     | `2.0.13`            |
+| `2.0.12`    | `2.0.12` - `2.0.13` | `2.0.14` - `2.0.15` |
+| `2.0.13`    | `2.0.14` - `2.0.17` | `2.0.16` - `2.0.22` |
+| `2.1.0`     | `2.1.0` - `2.1.2`   |                     |
+| `2.2.1`     | `2.1.3` - `2.1.4`   | `2.0.23`            |


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->
Fixes eiffel-community/eiffel-remrem-generate#213

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
Dockerfile uses tomcat:9.0.58-jdk17-openjdk-slim as a base image.

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits
<!-- What benefits will be realized by the change? -->
Docker image doesn't crash.

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Roman Szturc roman.szturc.ext@ericsson.com
