### PR TITLE
Service responds HTTP status 504 in case of LDAP timeout

### DIFF
--- a/publish-service/src/main/java/com/ericsson/eiffel/remrem/publish/config/CustomAuthenticationEntryPoint.java
+++ b/publish-service/src/main/java/com/ericsson/eiffel/remrem/publish/config/CustomAuthenticationEntryPoint.java
@@ -6,7 +6,6 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import groovyjarjarantlr4.v4.misc.FrequencySet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;

--- a/publish-service/src/main/java/com/ericsson/eiffel/remrem/publish/config/CustomAuthenticationEntryPoint.java
+++ b/publish-service/src/main/java/com/ericsson/eiffel/remrem/publish/config/CustomAuthenticationEntryPoint.java
@@ -6,10 +6,12 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import groovyjarjarantlr4.v4.misc.FrequencySet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.InternalAuthenticationServiceException;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
@@ -26,6 +28,17 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
         if (authException instanceof BadCredentialsException) {
             LOGGER.warn("Bad Credentials {}", HttpStatus.UNAUTHORIZED);
             response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Invalid credentials");
+        }
+        else if (authException instanceof InternalAuthenticationServiceException) {
+            Throwable cause = authException.getCause();
+            if (cause instanceof org.springframework.ldap.CommunicationException communicationException) {
+                cause = communicationException.getCause();
+                if (cause instanceof javax.naming.CommunicationException namingCommunicationException) {
+                    LOGGER.warn("Communication problem: {}: {}", HttpStatus.GATEWAY_TIMEOUT, namingCommunicationException.toString());
+                    response.sendError(HttpServletResponse.SC_GATEWAY_TIMEOUT, namingCommunicationException.toString());
+                    response.flushBuffer();
+                }
+            }
         }
     }
 }

--- a/publish-service/src/main/java/com/ericsson/eiffel/remrem/publish/config/CustomAuthenticationEntryPoint.java
+++ b/publish-service/src/main/java/com/ericsson/eiffel/remrem/publish/config/CustomAuthenticationEntryPoint.java
@@ -34,8 +34,9 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
             if (cause instanceof org.springframework.ldap.CommunicationException communicationException) {
                 cause = communicationException.getCause();
                 if (cause instanceof javax.naming.CommunicationException namingCommunicationException) {
-                    LOGGER.warn("Communication problem: {}: {}", HttpStatus.GATEWAY_TIMEOUT, namingCommunicationException.toString());
-                    response.sendError(HttpServletResponse.SC_GATEWAY_TIMEOUT, namingCommunicationException.toString());
+                    String message = namingCommunicationException.toString();
+                    LOGGER.warn("Communication problem: {}; {}", HttpStatus.GATEWAY_TIMEOUT, message);
+                    response.sendError(HttpServletResponse.SC_GATEWAY_TIMEOUT, message);
                     response.flushBuffer();
                 }
             }


### PR DESCRIPTION
<body>

<!--
Filling out the template is required.
Any pull request that does not include enough information to be reviewed in a timely
manner may be closed at the maintainers' discretion.
Any pull request must pass all automated tests and, if applicable, code style checks.
In addition the pull request must contain tests that cover any new code.
-->

### Applicable Issues
<!--
Reference any relevant issues here. Every pull request should refer to at least one
issue. For exemptions to this rule, see the [contribution guidelines](./CONTRIBUTING.md).
If an issue can be closed when the PR is merged, please use the
[standard notation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
to link the PR to the issue and make sure the latter is closed automatically when the PR
is merged.
-->

### Description of the Change
<!--
Describe the change proposed and its benefits. The maintainers must be able to
understand the design of your change from this description. If we can't get a good idea
of what the code will be doing from this description, the pull request may be closed at
the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not
be familiar with or have worked with the sources addressed by this PR recently, so
please walk us through the concepts. Provide special attention to breaking changes.
-->
When LDAP request timeouts, publish service responds HTTP status 504 instead of 401. 
401 status confused users as they expected incorrect password was submitted.

### Alternate Designs
<!--
Explain what other alternates were considered and why the proposed version was selected.
-->

### Possible Drawbacks
<!-- Describe the possible side-effects or negative impacts of this change. -->

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Roman Szturc roman.szturc.ext@ericsson.com
